### PR TITLE
Bring imports up to latest standards

### DIFF
--- a/Toast.js
+++ b/Toast.js
@@ -6,9 +6,9 @@
  */
 
 import React, {
-    Component,
-    PropTypes,
+    Component
 } from 'react'
+import PropTypes from 'prop-types'
 import {
     View,
     Text,
@@ -16,6 +16,7 @@ import {
     Animated,
     Easing,
     Dimensions,
+    ViewPropTypes
 } from 'react-native'
 
 import TimerEnhance from 'react-native-smart-timer-enhance'
@@ -53,7 +54,7 @@ class Toast extends Component {
     }
 
     static propTypes = {
-        style: View.propTypes.style,
+        style: ViewPropTypes.style,
         textStyle: Text.propTypes.style,
         spacing: PropTypes.number,
         position: PropTypes.oneOf([gravity.top, gravity.bottom, gravity.center,]),

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/react-native-component/react-native-smart-toast#readme",
   "dependencies": {
+    "prop-types": "^15.6.1",
     "react-native-smart-timer-enhance": "^1.0.2"
   }
 }


### PR DESCRIPTION
PropTypes imported from react-native is deprecated, and View.propTypes.styles has also been changed to ViewPropTypes imported from react-native. These issues are causing startup crashes in release mode and failed debug builds.